### PR TITLE
update pyzstd 0.16.2 -> 0.19.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pyzstd" %}
 {% set version = "0.19.1" %}
-{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -11,18 +10,17 @@ source:
   sha256: 36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - hatch-vcs
     - pip
   run:
-    - python >={{ python_min }}
+    - python >=3.10
     - backports.zstd >=1.0.0
     - typing-extensions >=4.13.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - hatch-vcs
     - pip
   run:
-    - python >=3.10
+    - python
     - backports.zstd >=1.0.0
     - typing-extensions >=4.13.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pyzstd" %}
-{% set version = "0.16.2" %}
+{% set version = "0.19.1" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,23 +8,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 179c1a2ea1565abf09c5f2fd72f9ce7c54b2764cf7369e05c0bfd8f1f67f63d2
+  sha256: 36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72
 
 build:
+  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --config-settings="--build-option=--dynamic-link-zstd" -vv .
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
-    - python
-    - setuptools >=64,<74
-    - wheel
+    - python {{ python_min }}
+    - hatchling
+    - hatch-vcs
     - pip
-    - zstd 1.5.6
   run:
-    - python
+    - python >={{ python_min }}
+    - backports.zstd >=1.0.0
+    - typing-extensions >=4.13.2
 
 test:
   source_files:
@@ -43,10 +44,11 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Python bindings to Zstandard (zstd) compression library
+  summary: Support for Zstandard (zstd) compression
   description: |
-    Pyzstd module provides classes and functions for compressing and decompressing data, using Facebook's Zstandard (or zstd as short name) algorithm. The API is similar to Python's bz2/lzma/zlib module.
+    Pyzstd module provides classes and functions for compressing and decompressing data, using Facebook's Zstandard (or zstd as short name) algorithm. The API style is similar to Python's bz2/lzma/zlib modules.
 
 extra:
   recipe-maintainers:
     - animalize
+    - rogdham


### PR DESCRIPTION
## Links
- PyPI: https://pypi.org/project/pyzstd/0.19.1
- PyPI Inspector: https://inspector.pypi.io/project/pyzstd/0.19.1

## Changes
- Update version 0.16.2 → 0.19.1
- Package is now `noarch: python` — since 0.19.0 it delegates to the stdlib
  `compression.zstd` module (Python 3.14+) or `backports.zstd` for older Pythons;
  no C extension is built
- Switch build system from setuptools to hatchling + hatch-vcs
- Remove build-time C compiler and zstd C library dependencies
- Add run deps: `backports.zstd >=1.0.0`, `typing-extensions >=4.13.2`
- Update summary, description, and recipe maintainers

## Notes
- Jira: PKG-15517